### PR TITLE
install python-crados

### DIFF
--- a/dockerhub/travis-ci-image.dockerfile
+++ b/dockerhub/travis-ci-image.dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && apt-get install -qy \
 # For Ceph
         librados-dev \
         liberasurecode-dev \
+        python-rados \
         ceph \
 # For prometheus
         libsnappy-dev \


### PR DESCRIPTION
python-rados have all features that cradox have for a while now.

I think, it's time to deprecated and drop cradox.

This change adds python-rados to the image, so we can remove it from
gnocchi dependencies.