### PR TITLE
Install python 3.7

### DIFF
--- a/dockerhub/travis-ci-image.dockerfile
+++ b/dockerhub/travis-ci-image.dockerfile
@@ -2,6 +2,8 @@ FROM ubuntu:16.04
 ENV GNOCCHI_SRC /home/tester/src
 ENV DEBIAN_FRONTEND noninteractive
 
+RUN echo 'deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu xenial main' >> /etc/apt/sources.list
+RUN apt-key adv --recv-keys --keyserver keyserver.ubuntu.com F23C5A6CF475977595C89F51BA6932366A755776
 RUN apt-get update -y && apt-get install -qy \
         locales \
         git \
@@ -11,8 +13,12 @@ RUN apt-get update -y && apt-get install -qy \
         npm \
         python \
         python3 \
+        python3.5 \
+        python3.7 \
         python-dev \
         python3-dev \
+        python3.5-dev \
+        python3.7-dev \
 # Needed for uwsgi core routing support
         libpcre3-dev \
         python-pip \


### PR DESCRIPTION
This changes use deadsnake ppa to install python 3.7.

It forces install of 3.5, to ensure we didn't break the CI during the
transition.