### PR TITLE
Change Ubuntu archive to old-releases

### DIFF
--- a/dockerhub/travis-ci-image.dockerfile
+++ b/dockerhub/travis-ci-image.dockerfile
@@ -39,7 +39,7 @@ RUN apt-get update -y && apt-get install -qy \
         libprotobuf-dev
 
 # Install Redis from more recent version of Ubuntu to have >= 3.2 and not only 3.0
-RUN echo 'deb http://archive.ubuntu.com/ubuntu artful universe' > /etc/apt/sources.list
+RUN echo 'deb http://old-releases.ubuntu.com/ubuntu artful universe' > /etc/apt/sources.list
 RUN apt-get update -y && apt-get install -qy \
         redis-server \
         && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fix the current situation before starting the
move to Ubuntu 18.04 or 20.04