### PR TITLE
Bump s3rver to 3.7.0

### DIFF
--- a/dockerhub/travis-ci-image.dockerfile
+++ b/dockerhub/travis-ci-image.dockerfile
@@ -48,7 +48,7 @@ RUN locale-gen $LANG
 #NOTE(sileht): Upgrade python dev tools
 RUN python3.6 -m pip install -U pip tox virtualenv
 
-RUN npm install s3rver@1.0.3 --global
+RUN npm install s3rver@3.7.0 --global
 
 RUN groupadd --gid 2000 tester
 RUN useradd --uid 2000 --gid 2000 --create-home --shell /bin/bash tester


### PR DESCRIPTION
This bumps s3rver to 3.7.0 which requires https://github.com/jd/pifpaf/pull/146 and a new release of pifpaf.

See question about new release in https://github.com/jd/pifpaf/pull/150